### PR TITLE
CI: Build on Debian oldstable

### DIFF
--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -34,8 +34,8 @@ jobs:
       - name: Install dependencies
         run: |
           apt-get update
-          apt-get install -y \
-            build-essential cmake qtbase5-dev
+          apt-get install -y --no-install-recommends \
+            build-essential cmake qtbase5-dev curl
 
       - name: Build
         run:  etc/ci/build

--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -26,7 +26,7 @@ jobs:
   build:
     name: Linux x86_64 (Continuous)
     runs-on: ubuntu-latest
-    container: debian:buster-slim
+    container: debian:oldstable-slim
 
     steps:
       - uses: actions/checkout@v4
@@ -35,19 +35,7 @@ jobs:
         run: |
           apt-get update
           apt-get install -y \
-            build-essential qtbase5-dev python3-pip p7zip-full unzip curl
-          curl -sLOC- 'http://http.us.debian.org/debian/pool/main/x/xcb-util/libxcb-util1_0.4.0-1+b1_amd64.deb'
-          dpkg -i libxcb-util1*.deb
-
-      - name: Install Qt
-        uses: jurplel/install-qt-action@v4
-        with:
-          install-deps: false
-          cache: true
-          setup-python: false
-
-      - name: Install CMake
-        uses: lukka/get-cmake@latest
+            build-essential cmake qtbase5-dev
 
       - name: Build
         run:  etc/ci/build

--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -35,7 +35,8 @@ jobs:
         run: |
           apt-get update
           apt-get install -y --no-install-recommends \
-            build-essential cmake qtbase5-dev curl ca-certificates
+            build-essential cmake qtbase5-dev ninja-build \
+            ca-certificates curl file
 
       - name: Build
         run:  etc/ci/build

--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -35,7 +35,7 @@ jobs:
         run: |
           apt-get update
           apt-get install -y --no-install-recommends \
-            build-essential cmake qtbase5-dev curl
+            build-essential cmake qtbase5-dev curl ca-certificates
 
       - name: Build
         run:  etc/ci/build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ jobs:
   build:
     name: Linux x86_64 (Release)
     runs-on: ubuntu-latest
-    container: debian:buster-slim
+    container: debian:oldstable-slim
 
     steps:
       - uses: actions/checkout@v4
@@ -17,20 +17,9 @@ jobs:
       - name: Install dependencies
         run: |
           apt-get update
-          apt-get install -y \
-            build-essential qtbase5-dev python3-pip p7zip-full unzip curl
-          curl -sLOC- 'http://http.us.debian.org/debian/pool/main/x/xcb-util/libxcb-util1_0.4.0-1+b1_amd64.deb'
-          dpkg -i libxcb-util1*.deb
-
-      - name: Install Qt
-        uses: jurplel/install-qt-action@v4
-        with:
-          install-deps: false
-          cache: true
-          setup-python: false
-
-      - name: Install CMake
-        uses: lukka/get-cmake@latest
+          apt-get install -y --no-install-recommends \
+            build-essential cmake qtbase5-dev ninja-build \
+            ca-certificates curl file
 
       - name: Determine version
         run:  printf 'VERSION=%s\n' "${GITHUB_REF##*/v}" >> "${GITHUB_ENV}"
@@ -59,12 +48,9 @@ jobs:
       - name: Download artifacts
         uses: actions/download-artifact@v4
 
-      - name: Inspect downloaded artifacts
-        run:  ls -lFR
-
       - name: Determine version
-        run:  printf 'VERSION=%s\n'
-          $(echo AppImage/DragDrop-*.AppImage | cut -f2 -d-) >> "${GITHUB_ENV}"
+        run:  echo AppImage/*.AppImage |
+          awk -F- '{print "VERSION=" $2}' >> "${GITHUB_ENV}"
 
       - name: Create release
         uses: ncipollo/release-action@v1

--- a/etc/ci/build
+++ b/etc/ci/build
@@ -1,4 +1,4 @@
-#!/bin/sh -efu
+#!/bin/sh -efux
 if command -v ninja >/dev/null 2>&1; then
 	use_ninja=-GNinja
 fi

--- a/etc/ci/build
+++ b/etc/ci/build
@@ -6,5 +6,5 @@ build_type=${VERSION:+Release}
 
 cmake -S . -B build ${use_ninja:-} \
 	-DCMAKE_BUILD_TYPE="${build_type:-RelWithDebInfo}" \
-	--install-prefix /usr
+	-DCMAKE_INSTALL_PREFIX="/usr"
 cmake --build build

--- a/etc/ci/package
+++ b/etc/ci/package
@@ -1,4 +1,4 @@
-#!/bin/sh -efu
+#!/bin/sh -efux
 ld_url='https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage'
 qt_url='https://github.com/linuxdeploy/linuxdeploy-plugin-qt/releases/download/continuous/linuxdeploy-plugin-qt-x86_64.AppImage'
 


### PR DESCRIPTION
Installing Qt5 on Buster is  failing, and I don't want to figure out why. Bullseye is probably old enough at this point that most distros should have a glibc that's the same or newer than it.